### PR TITLE
Only return cleanup function from useEffect if domRef.current is defined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,10 +22,14 @@ export default (domRef, {
   );
 
   useEffect(() => {
-    const onScroll = () => { wasScrolled.current = isScrolled(); };
 
-    domRef.current.addEventListener('scroll', onScroll);
-    return () => domRef.current.removeEventListener('scroll', onScroll);
+    const currentRef = domRef.current;
+    if (!currentRef) return;
+    
+    const onScroll = () => { wasScrolled.current = isScrolled(); };
+    currentRef.addEventListener('scroll', onScroll);
+    
+    return () => currentRef.removeEventListener('scroll', onScroll);
   }, []);
 
   const scroll = useCallback((position) => {


### PR DESCRIPTION
Fixes `Fix TypeError: Cannot read property 'removeEventListener' of null` that would sometimes occur.

Fixes the following ESLint error: `The ref value 'domRef.current' will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by React, copy 'domRef.current' to a variable inside the effect, and use that variable in the cleanup function.`