### PR TITLE
Fix for the removeEventListener of null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ export default (domRef, {
   useEffect(() => {
     const onScroll = () => { wasScrolled.current = isScrolled(); };
 
-    ref.addEventListener('scroll', onScroll);
+    domRef.current.addEventListener('scroll', onScroll);
     // in react 17 the cleanup can happen after the element gets unmounted
     return () => domRef.current?.removeEventListener('scroll', onScroll);
   }, []);

--- a/src/index.js
+++ b/src/index.js
@@ -26,8 +26,7 @@ export default (domRef, {
 
     domRef.current.addEventListener('scroll', onScroll);
     return () => {
-      if (domRef.current)
-        domRef.current.removeEventListener('scroll', onScroll);
+        domRef.current?.removeEventListener('scroll', onScroll);
     }
   }, []);
 

--- a/src/index.js
+++ b/src/index.js
@@ -22,12 +22,12 @@ export default (domRef, {
   );
 
   useEffect(() => {
+    const ref = domRef.current;
     const onScroll = () => { wasScrolled.current = isScrolled(); };
-
-    domRef.current.addEventListener('scroll', onScroll);
-    return () => {
-        domRef.current?.removeEventListener('scroll', onScroll);
-    }
+    
+    ref.addEventListener('scroll', onScroll);
+    
+    return () => { ref.removeEventListener('scroll', onScroll); };
   }, []);
 
   const scroll = useCallback((position) => {

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,10 @@ export default (domRef, {
     const onScroll = () => { wasScrolled.current = isScrolled(); };
 
     domRef.current.addEventListener('scroll', onScroll);
-    return () => domRef.current.removeEventListener('scroll', onScroll);
+    return () => {
+      if (domRef.current)
+        domRef.current.removeEventListener('scroll', onScroll);
+    }
   }, []);
 
   const scroll = useCallback((position) => {

--- a/src/index.js
+++ b/src/index.js
@@ -22,12 +22,11 @@ export default (domRef, {
   );
 
   useEffect(() => {
-    const ref = domRef.current;
     const onScroll = () => { wasScrolled.current = isScrolled(); };
-    
+
     ref.addEventListener('scroll', onScroll);
-    
-    return () => { ref.removeEventListener('scroll', onScroll); };
+    // in react 17 the cleanup can happen after the element gets unmounted
+    return () => domRef.current?.removeEventListener('scroll', onScroll);
   }, []);
 
   const scroll = useCallback((position) => {


### PR DESCRIPTION
On React 17.x.x there's the following error while unmounting a `stayScrolled` component. This fixes it.

`Cannot read property 'removeEventListener' of null`